### PR TITLE
[DISCO-2194] Fix grunt write

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ hashres: {
     encoding: 'utf8',
     // Optional. Format used to name the files specified in 'files' property. 
     // Default value: '${hash}.${name}.cache.${ext}'
-    fileNameFormat: '${hash}.${name}.cache.${ext}'
+    fileNameFormat: '${hash}.${name}.cache.${ext}',
+    // Optional. Should files be renamed or only alter the references to the files
+    // Default value: true
+    renameFiles: true
   }
 }
 ```
@@ -53,12 +56,14 @@ according to the pattern specified in this property. The following variables are
   * ```${hash}```: the first 8 digits of the md5 of the file.
   * ```${name}```: the original name of the file.
   * ```${ext}```: the original extension of the file.
+* ```renameFiles```: Rename the files or leave them in place and only alter the references to them in ```out```. Defaults to ```true```
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. 
 Add unit tests for any new or changed functionality. Lint and test your code using [grunt][grunt].
 
 ## Release History
+* 19/11/12 - 0.2.1: Optional File Renaming
 * 14/11/12 - 0.1.5: Feature request [#1](https://github.com/Luismahou/grunt-hashres/issues/1): ```fileNameFormat``` property added.
 * 02/11/12 - 0.1.3: First working release.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-hashres",
   "description": "Hashes your js and css files and rename the <script> and <link> declarations that refer to them in your html/php/etc files.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/Luismahou/grunt-hashres",
   "author": {
     "name": "Luismahou"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-hashres",
   "description": "Hashes your js and css files and rename the <script> and <link> declarations that refer to them in your html/php/etc files.",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "homepage": "https://github.com/Luismahou/grunt-hashres",
   "author": {
     "name": "Luismahou"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-hashres",
   "description": "Hashes your js and css files and rename the <script> and <link> declarations that refer to them in your html/php/etc files.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/Luismahou/grunt-hashres",
   "author": {
     "name": "Luismahou"

--- a/tasks/hashres.js
+++ b/tasks/hashres.js
@@ -26,7 +26,10 @@ module.exports = function(grunt) {
       out           : this.data.out,
       encoding      : this.data.encoding,
       fileNameFormat: this.data.fileNameFormat,
-      renameFiles   : this.data.renameFiles
+      renameFiles   : this.data.renameFiles,
+      writeManifest : this.data.writeManifest,
+      manifestName  : this.data.manifestName,
+      manifestFile  : this.data.manifestFile
     });
   });
 };

--- a/tasks/hashres.js
+++ b/tasks/hashres.js
@@ -29,7 +29,9 @@ module.exports = function(grunt) {
       renameFiles   : this.data.renameFiles,
       writeManifest : this.data.writeManifest,
       manifestName  : this.data.manifestName,
-      manifestFile  : this.data.manifestFile
+      manifestFile  : this.data.manifestFile,
+      baseDir       : this.data.baseDir,
+      httpDir       : this.data.httpDir
     });
   });
 };

--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -17,8 +17,8 @@ var setupDefaultOptions = function(options) {
     encoding: (options.encoding || 'utf8'),
     fileNameFormat: (options.fileNameFormat || '${hash}.${name}.cache.${ext}'),
     renameFiles: (options.renameFiles === undefined ? true : false),
-    manifestName: "FileManifest",
-    manifestFile: "manifest.js",
+    manifestName: options.manifestName || "FileManifest",
+    manifestFile: options.manifestFile || "manifest.js",
     writeManifest: options.writeManifest || false,
     baseDir: options.baseDir || null,
     httpDir: options.httpDir || null

--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -53,6 +53,7 @@ var buildHashMapping = function(grunt, options) {
 };
 
 var writeManifest = function(grunt, options, nameToHashedName) {
+  grunt.log.ok('writing manifest to ' + options.manifestFile);
   grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName) + ";", options.encoding);
 };
 

--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -19,7 +19,9 @@ var setupDefaultOptions = function(options) {
     renameFiles: (options.renameFiles === undefined ? true : false),
     manifestName: "FileManifest",
     manifestFile: "manifest.js",
-    writeManifest: options.writeManifest || false
+    writeManifest: options.writeManifest || false,
+    baseDir: options.baseDir || null,
+    httpDir: options.httpDir || null
   };
 };
 
@@ -31,13 +33,17 @@ var buildHashMapping = function(grunt, options) {
 
   // Renaming the files using a unique name
   grunt.file.expand(options.files).forEach(function(f) {
-    var md5 = utils.md5(f).slice(0, 8),
-        fileName = path.basename(f),
-        lastIndex = fileName.lastIndexOf('.'),
-        renamed = formatter({
-          hash: md5,
-          name: fileName.slice(0, lastIndex),
-          ext: fileName.slice(lastIndex + 1, fileName.length) });
+    var fileName = path.basename(f), md5, lastIndex, renamed;
+    if (options.baseDir) {
+      fileName = f.replace(options.baseDir, options.httpDir || '');
+    }
+    md5 = utils.md5(f).slice(0, 8);
+    lastIndex = fileName.lastIndexOf('.');
+    renamed = formatter({
+      hash: md5,
+      name: fileName.slice(0, lastIndex),
+      ext: fileName.slice(lastIndex + 1, fileName.length)
+    });
 
     // Mapping the original name with hashed one for later use.
     nameToHashedName[fileName] = renamed;
@@ -54,7 +60,7 @@ var buildHashMapping = function(grunt, options) {
 
 var writeManifest = function(grunt, options, nameToHashedName) {
   grunt.log.ok('writing manifest to ' + options.manifestFile);
-  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName) + ";", options.encoding);
+  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName, null, "  ") + ";", options.encoding);
 };
 
 exports.hashAndSub = function(grunt, options) { //files, out, encoding, fileNameFormat) {

--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -10,13 +10,13 @@ var fs    = require('fs'),
     path  = require('path'),
     utils = require('./hashresUtils');
 
-var setupDefaultOptions = function(grunt, options) {
+var setupDefaultOptions = function(options) {
   return {
     files: Array.isArray(options.files) ? options.files : [options.files],
     out: Array.isArray(options.out) ? options.out: [options.out],
     encoding: (options.encoding || 'utf8'),
     fileNameFormat: (options.fileNameFormat || '${hash}.${name}.cache.${ext}'),
-    renameFiles: (options.renameFiles === undefined? true : false),
+    renameFiles: (options.renameFiles === undefined ? true : false),
     manifestName: "FileManifest",
     manifestFile: "manifest.js",
     writeManifest: options.writeManifest || false

--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -60,7 +60,7 @@ var buildHashMapping = function(grunt, options) {
 
 var writeManifest = function(grunt, options, nameToHashedName) {
   grunt.log.ok('writing manifest to ' + options.manifestFile);
-  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName, null, "  ") + ";", options.encoding);
+  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName, null, "  ") + ";", { encoding: options.encoding });
 };
 
 exports.hashAndSub = function(grunt, options) { //files, out, encoding, fileNameFormat) {


### PR DESCRIPTION
In https://paperlesspost.atlassian.net/browse/DISCO-2194,

We want to make sure that writing a manifest.js will work. While it might not actually be necessary for prod, the reason why it's failing is because we want to upgrade the version that we're using for grunt, and we should do the same to its dependencies too. 

As of Grunt V1, they want an encoding to be in an object instead of its own argument by itself.